### PR TITLE
lock md5 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "uglify-js": "~2.3.6",
     "async": "~0.2.9",
-    "md5": "*"
+    "md5": "^1.1.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This is currently breaking dependents.